### PR TITLE
Fix password typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You need to update settings and add your own data into configuration file */etc/
   - username - username
   - network - address, from which mysql allows to connect this user. e.g. *8.8.%*  
   - password - plain-text password. I would not recommend to have it. Better use *hashedPassword*. If specifyed - *hashedPassword* will be ignored  
-  - hashedPassword - hashed password (sha1 encrypted). You can get it via ```mysql> select password('password')``` e.g. **\*F41E614E894A46E0FB7317B1C8CB6CEA97415C7B**  
+  - hashedPassword - hashed password (sha1 encrypted). You can get it via ```mysql> select password('oleg')``` e.g. **\*F41E614E894A46E0FB7317B1C8CB6CEA97415C7B**
   - grantOption - true or false flag for users "WITH GRANT OPTION". Default *false*  
   
 - **[[user.permissions]]**


### PR DESCRIPTION
F41E614E894A46E0FB7317B1C8CB6CEA97415C7B is obviously not the
hash of 'password', but rather 'oleg'. Don't lie to your users!
